### PR TITLE
Design | noTicket: Fixes Main Wrapper Width

### DIFF
--- a/build/main.css
+++ b/build/main.css
@@ -7,7 +7,7 @@
 .bento-component-wrapper {
   display: flex;
   flex-direction: column;
-  max-width: 360px;
+  width: 360px;
   margin: 0 auto; }
   .bento-component-wrapper * {
     align-self: center; }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -20,7 +20,7 @@
 .bento-component-wrapper {
     display: flex;
     flex-direction: column;
-    max-width: 360px;
+    width: 360px;
     margin: 0 auto;
     * {
         align-self: center;


### PR DESCRIPTION
This PR fixes the mainWrapper width to make it works when embedded within Frontify.